### PR TITLE
photo-share listens for photo updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,24 @@ ng serve
 When you look at:  http://localhost:4200/
 
 It will look like this:
-![hatmirrorphoneinterface](https://user-images.githubusercontent.com/1727761/29428726-d221466a-8353-11e7-8631-a9e9976fd3fc.png)
+<img width="518" alt="phoneapp2" src="https://user-images.githubusercontent.com/1727761/29830139-fbe73084-8ca6-11e7-9df3-5569553d7e2e.png">
 
-This project was generated with [angular-cli](https://github.com/angular/angular-cli) version 1.0.0-beta.24.
+This project has been updated to these versions:
+```
+@angular/cli: 1.3.0
+node: 6.10.0
+os: darwin x64
+@angular/common: 2.4.10
+@angular/compiler: 2.4.10
+@angular/core: 2.4.10
+@angular/forms: 2.4.10
+@angular/http: 2.4.10
+@angular/platform-browser: 2.4.10
+@angular/platform-browser-dynamic: 2.4.10
+@angular/router: 3.4.10
+@angular/cli: 1.3.0
+@angular/compiler-cli: 2.4.10
+```
 
 ## Development server
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/angular-cli.json
+++ b/angular-cli.json
@@ -41,6 +41,9 @@
     }
   },
   "defaults": {
+    "serve": {
+      "port": 4200
+    },
     "styleExt": "css",
     "prefixInterfaces": false,
     "inline": {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,10 +9,12 @@ import { PhotoShareComponent } from './photo-share/photo-share.component';
 import { PurchaseComponent } from './purchase/purchase.component';
 import { SyncComponent } from './sync/sync.component';
 
-import { SocketService } from './socket.service';
+import { SocketService } from './shared/socket.service';
+import { stateInit } from './shared/stateInit';
+
 
 const config: SocketIoConfig = {
-    url: 'ec2-54-221-218-6.compute-1.amazonaws.com:4000',
+    url: stateInit.socket_url,
     options: {}
 };
 

--- a/src/app/photo-share/photo-share.component.html
+++ b/src/app/photo-share/photo-share.component.html
@@ -1,3 +1,9 @@
 <p>
   photo-share works!
 </p>
+<h3>Picture</h3>
+<ul>
+  <li *ngFor="let picture of pictures">
+    {{ picture }}
+  </li>
+</ul>

--- a/src/app/photo-share/photo-share.component.ts
+++ b/src/app/photo-share/photo-share.component.ts
@@ -1,15 +1,35 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { SocketService } from '../shared/socket.service';
+
+interface PicturesListType {
+  pictures: string[];
+}
 
 @Component({
   selector: 'app-photo-share',
   templateUrl: './photo-share.component.html',
   styleUrls: ['./photo-share.component.css']
 })
-export class PhotoShareComponent implements OnInit {
+export class PhotoShareComponent implements OnInit, OnDestroy {
 
-  constructor() { }
+  pictures = [];
+  newPicturesObserver;
+
+  constructor(
+    private socketService: SocketService
+  ) { }
 
   ngOnInit() {
+    this.newPicturesObserver = this.socketService
+      .getNewPictures()
+      .subscribe((data:PicturesListType) => {
+        this.pictures = data.pictures;
+      });
+  }
+
+  ngOnDestroy() {
+    this.newPicturesObserver.unsubscribe();
   }
 
 }

--- a/src/app/shared/socket.service.ts
+++ b/src/app/shared/socket.service.ts
@@ -39,4 +39,19 @@ export class SocketService {
     return observable;
   }
 
+  getNewPictures() {
+    let observable = new Observable(observer => {
+      this.socket.on('newPictures', (data) => {
+        console.log('data = ' + JSON.stringify(data, null, 2));
+        observer.next(data);
+      });
+
+      return () => {
+        this.socket.disconnect();
+      };
+    })
+
+    return observable;
+  }
+
 }

--- a/src/app/shared/stateInit.ts
+++ b/src/app/shared/stateInit.ts
@@ -1,0 +1,4 @@
+export const stateInit = {
+  socket_url: 'ec2-54-221-218-6.compute-1.amazonaws.com:4000',
+}
+

--- a/src/app/sync/sync.component.ts
+++ b/src/app/sync/sync.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { SocketService } from '../socket.service';
+import { SocketService } from '../shared/socket.service';
 
 @Component({
   selector: 'app-sync',
@@ -42,6 +42,7 @@ export class SyncComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.connectObserver.unsubscribe();
     this.problemObserver.unsubscribe();
   }
 


### PR DESCRIPTION
This is the phone app, served by cloud-node.  I modified the photo-share component to listen for the 'newPictures' message and then display the paths of the pictures.  It is already copied to the cloud-node server, so after you merge it, you don't need to deploy it.
